### PR TITLE
[WIP] Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# SUBMISSION CHANGELOG
+
+# 0.0.0
+- configure a form with controls using yaml, an array or a fluid interface in PHP
+- modify a form following initial build
+- configure form renderers
+- `bare` and `bootstrap` renderers out-of-the-box.
+- add `classes` to controls with option of rendering based on the control class, e.g. `text.medium`
+- group `controls` together
+- validation supported through different vendor libraries, e.g. Laravel, ZF2, Assert


### PR DESCRIPTION
- [ ] configure a form with controls using yaml, an array or a fluid interface in PHP
- [ ] modify a form following initial build
- [ ] configure form renderers
- [ ] `bare` and `bootstrap` renderers out-of-the-box.
- [ ] add `classes` to controls with option of rendering based on the control class, e.g. `text.medium`
- [ ] group `controls` together
- [ ] validation supported through different vendor libraries, e.g. Laravel, ZF2, Assert